### PR TITLE
Solving the problem of Missing flag handling in ColorMyWorld  #1603

### DIFF
--- a/activities/ColorMyWorld.activity/lib/flag.js
+++ b/activities/ColorMyWorld.activity/lib/flag.js
@@ -218,7 +218,7 @@ define(function (require) {
         Burkina_Faso: "🇧🇫",
         Uruguay: "🇺🇾",
         Uzbekistan: "🇺🇿",
-        Saint_Vincent: "🇻🇨",
+        Saint_Vincent_and_the_Grenadines: "🇻🇨",
         Venezuela: "🇻🇪",
         United_States_Virgin_Islands: "🇻🇮",
         Namibia: "🇳🇦",

--- a/activities/ColorMyWorld.activity/locales/en.json
+++ b/activities/ColorMyWorld.activity/locales/en.json
@@ -242,7 +242,7 @@
 	"Burkina_Faso": "Burkina_Faso",
 	"Uruguay": "Uruguay",
 	"Uzbekistan": "Uzbekistan",
-	"Saint_Vincent": "Saint_Vincent_and_the_Grenadines",
+	"Saint_Vincent_and_the_Grenadines": "Saint_Vincent_and_the_Grenadines",
 	"Venezuela": "Venezuela",
 	"United_States_Virgin_Islands": "United_States_Virgin_Islands",
 	"Namibia": "Namibia",

--- a/activities/ColorMyWorld.activity/locales/es.json
+++ b/activities/ColorMyWorld.activity/locales/es.json
@@ -238,7 +238,7 @@
 	"Burkina_Faso": "Burkina Faso",
 	"Uruguay": "Uruguay",
 	"Uzbekistan": "Ouzbékistan",
-	"Saint_Vincent": "Saint-Vincent-et-les-Grenadines",
+	"Saint_Vincent_and_the_Grenadines": "Saint-Vincent-et-les-Grenadines",
 	"Venezuela": "Venezuela",
 	"United_States_Virgin_Islands": "Îles_Vierges_américaines",
 	"Namibia": "Namibie",

--- a/activities/ColorMyWorld.activity/locales/fr.json
+++ b/activities/ColorMyWorld.activity/locales/fr.json
@@ -239,7 +239,7 @@
 	"Burkina_Faso": "Burkina_Faso",
 	"Uruguay": "Uruguay",
 	"Uzbekistan": "Ouzbékistan",
-	"Saint_Vincent": "Saint-Vincent-et-les-Grenadines",
+	"Saint_Vincent_and_the_Grenadines": "Saint-Vincent-et-les-Grenadines",
 	"Venezuela": "Venezuela",
 	"United_States_Virgin_Islands": "Îles_Vierges_américaines",
 	"Namibia": "Namibie",

--- a/activities/ColorMyWorld.activity/locales/gr.json
+++ b/activities/ColorMyWorld.activity/locales/gr.json
@@ -238,7 +238,7 @@
 	"Burkina_Faso": "Μπουρκίνα_Φάσο",
 	"Uruguay": "Ουρουγουάη",
 	"Uzbekistan": "Ουζμπεκιστάν",
-	"Saint_Vincent": "Άγιος_Βικέντιος_και_Γρεναδίνες",
+	"Saint_Vincent_and_the_Grenadines": "Άγιος_Βικέντιος_και_Γρεναδίνες",
 	"Venezuela": "Βενεζουέλα",
 	"United_States_Virgin_Islands": "Ηνωμένες_Πολιτείες_Παρθένοι_Νήσοι",
 	"Namibia": "Ναμίμπια",

--- a/activities/ColorMyWorld.activity/locales/it.json
+++ b/activities/ColorMyWorld.activity/locales/it.json
@@ -238,7 +238,7 @@
 	"Burkina_Faso": "Burkina_Faso",
 	"Uruguay": "Uruguay",
 	"Uzbekistan": "Uzbekistan",
-	"Saint_Vincent": "Saint_Vincent_e_Grenadine",
+	"Saint_Vincent_and_the_Grenadines": "Saint_Vincent_e_Grenadine",
 	"Venezuela": "Venezuela",
 	"United_States_Virgin_Islands": "Stati_Uniti_Isole_Vergini",
 	"Namibia": "Namibia",

--- a/activities/ColorMyWorld.activity/locales/sw.json
+++ b/activities/ColorMyWorld.activity/locales/sw.json
@@ -238,7 +238,7 @@
 	"Burkina_Faso": "Burkina_Faso",
 	"Uruguay": "Uruguay",
 	"Uzbekistan": "Uzbekistan",
-	"Saint_Vincent": "Saint_Vincent_na_Grenadines",
+	"Saint_Vincent_and_the_Grenadines": "Saint_Vincent_na_Grenadines",
 	"Venezuela": "Venezuela",
 	"United_States_Virgin_Islands": "Visiwa_vya_Virgin_vya_Marekani",
 	"Namibia": "Namibia",

--- a/activities/ColorMyWorld.activity/locales/th.json
+++ b/activities/ColorMyWorld.activity/locales/th.json
@@ -238,7 +238,7 @@
 	"Burkina_Faso": "Burkina_Faso",
 	"Uruguay": "อุรุกวัย",
 	"Uzbekistan": "อุซเบกิ",
-	"Saint_Vincent": "เซนต์วินเซนต์และเกรนาดีน",
+	"Saint_Vincent_and_the_Grenadines": "เซนต์วินเซนต์และเกรนาดีน",
 	"Venezuela": "เวเนซุเอลา",
 	"United_States_Virgin_Islands": "หมู่เกาะเวอร์จินของสหรัฐอเมริกา",
 	"Namibia": "นามิเบีย",


### PR DESCRIPTION
#1603
This is my first pull request to an open source project. I’ve made improvements to handle missing flags in ColorMyWorld, as detailed in issue #1603. Also when i am running the sugarizer using source code i can not see any flags with the country name and also can not see the country flags on the internet version of the sugarizer but the video you have provided shows it, what i have done is while clicking on the "SAINT VINCENT AND THE GRINADINES" it shows the name correctly without showing the undefined part. Please review it and tell me if it is okay, i have also added a video.

https://github.com/user-attachments/assets/d61668ca-ed1a-4558-a53d-d0d444751882



