### PR TITLE
Add Windows setup notes and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,17 +96,6 @@ set it to `false`.
 For **Safari** go to the `Safari/Preferences...` menu, under Advanced panel check the *Show develop menu in menu bar* box. Then from the `Develop` menu, select *Disable local file restrictions*.
 
 
-# Windows Setup Notes
-## Common Issues & Fixes
-### Git clone fails with RPC error
-If cloning fails with `RPC failed` or `early EOF`, run:
-
-```bash
-git config --global http.postBuffer 524288000
-git clone --depth 1 https://github.com/sugarlabs/sugarizer.git
-
-
-
 # Sugarizer Web Application
 
 [Try it now! (try.sugarizer.org)](http://try.sugarizer.org/)
@@ -329,3 +318,11 @@ Sugarizer is licensed under the **Apache-2.0** license. See [LICENSE](LICENSE) f
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fllaske%2Fsugarizer.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fllaske%2Fsugarizer?ref=badge_shield&issueType=license)
 
 
+# Windows Setup Notes
+## Common Issues & Fixes
+### Git clone fails with RPC error
+If cloning fails with `RPC failed` or `early EOF`, run:
+
+```bash
+git config --global http.postBuffer 524288000
+git clone --depth 1 https://github.com/sugarlabs/sugarizer.git

--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ set it to `false`.
 For **Safari** go to the `Safari/Preferences...` menu, under Advanced panel check the *Show develop menu in menu bar* box. Then from the `Develop` menu, select *Disable local file restrictions*.
 
 
+# Windows Setup Notes
+## Common Issues & Fixes
+### Git clone fails with RPC error
+If cloning fails with `RPC failed` or `early EOF`, run:
+
+```bash
+git config --global http.postBuffer 524288000
+git clone --depth 1 https://github.com/sugarlabs/sugarizer.git
+
+
 
 # Sugarizer Web Application
 
@@ -317,3 +327,5 @@ Sugarizer is licensed under the **Apache-2.0** license. See [LICENSE](LICENSE) f
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fllaske%2Fsugarizer.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fllaske%2Fsugarizer?ref=badge_shield&issueType=license)
+
+


### PR DESCRIPTION
### Problem
New contributors using Windows may face setup issues that are not
documented, which can slow down onboarding.

### Solution
This PR adds Windows-specific setup and troubleshooting notes to the
README based on real setup experience.

### How I Tested
- Tested on Windows
- Successfully ran `npm install`
- Successfully ran `npm start`
