### PR TITLE
Add tooltip to Journal icon on home screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ set it to `false`.
 For **Safari** go to the `Safari/Preferences...` menu, under Advanced panel check the *Show develop menu in menu bar* box. Then from the `Develop` menu, select *Disable local file restrictions*.
 
 
+# Windows Setup Notes
+## Common Issues & Fixes
+### Git clone fails with RPC error
+If cloning fails with `RPC failed` or `early EOF`, run:
+
+```bash
+git config --global http.postBuffer 524288000
+git clone --depth 1 https://github.com/sugarlabs/sugarizer.git
+
+
 
 # Sugarizer Web Application
 
@@ -317,3 +327,5 @@ Sugarizer is licensed under the **Apache-2.0** license. See [LICENSE](LICENSE) f
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fllaske%2Fsugarizer.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fllaske%2Fsugarizer?ref=badge_shield&issueType=license)
+
+

--- a/js/homeview.js
+++ b/js/homeview.js
@@ -28,10 +28,7 @@ enyo.kind({
 	kind: enyo.Control,
 	components: [
 		{name: "owner", kind: "Sugar.Icon", size: constant.sizeOwner, colorized: true, classes: "owner-icon", showing: false},
-		{name: "journal", kind: "Sugar.Icon", size: constant.sizeJournal, ontap: "showJournal", classes: "journal-icon", showing: false, attributes: {
-    title: "Journal",
-    "aria-label": "Journal"
-  }},
+		{name: "journal", kind: "Sugar.Icon", size: constant.sizeJournal, ontap: "showJournal", classes: "journal-icon", showing: false, attributes: {title: "Journal", "aria-label": "Journal"}},
 		{name: "desktop", showing: true, onresize: "resize", components: []},
 		{name: "otherview", showing: true, components: []},
 		{name: "activityPopup", kind: "Sugar.Popup", showing: false}

--- a/js/homeview.js
+++ b/js/homeview.js
@@ -28,7 +28,10 @@ enyo.kind({
 	kind: enyo.Control,
 	components: [
 		{name: "owner", kind: "Sugar.Icon", size: constant.sizeOwner, colorized: true, classes: "owner-icon", showing: false},
-		{name: "journal", kind: "Sugar.Icon", size: constant.sizeJournal, ontap: "showJournal", classes: "journal-icon", showing: false},
+		{name: "journal", kind: "Sugar.Icon", size: constant.sizeJournal, ontap: "showJournal", classes: "journal-icon", showing: false, attributes: {
+    title: "Journal",
+    "aria-label": "Journal"
+  }},
 		{name: "desktop", showing: true, onresize: "resize", components: []},
 		{name: "otherview", showing: true, components: []},
 		{name: "activityPopup", kind: "Sugar.Popup", showing: false}


### PR DESCRIPTION
### Problem
The Journal (book) icon on the home screen does not indicate its purpose
on hover, making it hard for users to understand without clicking.

### Solution
Added a tooltip and accessibility label to the Journal icon to improve
discoverability without changing behavior or layout.

### Video representation of the issue
https://github.com/user-attachments/assets/7e6f0092-c6ba-407b-9968-47be299f81e6

###Video representation of the issue after solving
https://github.com/user-attachments/assets/4d6b93e2-0c2f-47d8-9af9-3683d796689b

### How I Tested
- Ran the app locally with `npm start`
- Verified tooltip appears on hover over the Journal icon

### Note
I kept the tooltip text as **"Journal"** to match the existing activity name.
If a more descriptive label (for example, **"Activity Journal"**) is preferred,
I’m happy to update it based on maintainer feedback.