### PR TITLE
perf: add debounce to window resize

### DIFF
--- a/activities/Clock.activity/js/activity.js
+++ b/activities/Clock.activity/js/activity.js
@@ -103,6 +103,17 @@ define(["sugar-web/activity/activity","sugar-web/env","sugar-web/graphics/radiob
             window.msRequestAnimationFrame;
         var show_am_pm = false;
         var show_mins = false;
+        // Is function ko add karein
+function debounce(func, delay) {
+    var timer;
+    return function() {
+        var context = this, args = arguments;
+        clearTimeout(timer);
+        timer = setTimeout(function() {
+            func.apply(context, args);
+        }, delay);
+    };
+}
 
         function Clock() {
             this.face = "simple";
@@ -175,9 +186,9 @@ define(["sugar-web/activity/activity","sugar-web/env","sugar-web/graphics/radiob
 
             var that = this;
             window.onresize = function (event) {
-                that.updateSizes();
-                that.drawBackground();
-            };
+            that.updateSizes();
+            that.drawBackground();
+           };
 
             // Switch to full screen when the full screen button is pressed
             document.getElementById("fullscreen-button").addEventListener('click', function() {


### PR DESCRIPTION
This PR introduces a debounce function to the window resize event in clock-activity. Currently, the activity tries to redraw the clock on every single pixel change during a resize, which can be resource-intensive on low-end devices. ## PR Category
- [x] Bug Fix
- [x] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

By adding a 250ms debounce, the activity now waits for the user to finish resizing before recalculating sizes and redrawing the background.

Changes:

Added a utility debounce function in js/activity.js.

Wrapped the window.onresize event handler with the debounce function.

Impact:

Reduces CPU usage during window resizing.

Smoother UI experience on low-spec hardware (like XO laptops).

Testing:

Verified that the clock correctly adjusts its size after resizing.

Confirmed no lag during the resizing process.